### PR TITLE
Temporary disable file mount to quick fix crashing docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,8 +25,8 @@ services:
     build: ./backend/
     ports:
       - "8000:8000"
-    volumes:
-      - ./backend:/backend
+    # volumes:
+    #   - ./backend:/backend
     restart: always
     depends_on:
       database:
@@ -36,9 +36,9 @@ services:
     build: ./frontend/
     ports:
       - "4200:4200"
-    volumes:
-      - ./frontend/coding-challenge:/frontend
-      - node_modules:/frontend/node_modules
+    # volumes:
+    #   - ./frontend/coding-challenge:/frontend
+    #   - node_modules:/frontend/node_modules
     restart: always
     depends_on:
       - server


### PR DESCRIPTION
Something in the latest pull request seems to have corrupted the files. 
Volume mounts/hot reload are no longer possible until the issue gets solved.